### PR TITLE
Adds public token exchange and Stripe bank account token APIs

### DIFF
--- a/lib/plaidex.ex
+++ b/lib/plaidex.ex
@@ -21,4 +21,5 @@ defmodule Plaidex do
   defdelegate item(access_token, params \\ nil, endpoint \\ "item/get"), to: Plaidex.API.Base, as: :authenticated_post
   defdelegate webhook_update(access_token, params \\ nil, endpoint \\ "/item/webhook/update"), to: Plaidex.API.Base, as: :authenticated_post
   defdelegate item_delete(access_token, params \\ nil, endpoint \\ "/item/delete"), to: Plaidex.API.Base, as: :authenticated_post
+  defdelegate public_token_exchange(params \\ nil, endpoint \\ "item/public_token/exchange"), to: Plaidex.API.Base, as: :authenticated_post
 end

--- a/lib/plaidex.ex
+++ b/lib/plaidex.ex
@@ -22,4 +22,5 @@ defmodule Plaidex do
   defdelegate webhook_update(access_token, params \\ nil, endpoint \\ "/item/webhook/update"), to: Plaidex.API.Base, as: :authenticated_post
   defdelegate item_delete(access_token, params \\ nil, endpoint \\ "/item/delete"), to: Plaidex.API.Base, as: :authenticated_post
   defdelegate public_token_exchange(params \\ nil, endpoint \\ "item/public_token/exchange"), to: Plaidex.API.Base, as: :authenticated_post
+  defdelegate create_stripe_bank_token(access_token, params \\ nil, endpoint \\ "processor/stripe/bank_account_token/create"), to: Plaidex.API.Base, as: :authenticated_post
 end

--- a/lib/plaidex/api/base.ex
+++ b/lib/plaidex/api/base.ex
@@ -1,6 +1,8 @@
 defmodule Plaidex.API.Base do
   @moduledoc false
 
+  defdelegate environment_url, to: Plaidex.Config
+
   def get(endpoint, options \\ []) do
     endpoint
     |> url
@@ -71,14 +73,6 @@ defmodule Plaidex.API.Base do
     case response["error_code"] do
       nil -> {:ok, response}
       _er -> {:error, response}
-    end
-  end
-
-  defp environment_url do
-    case Mix.env do
-      :prod -> "production"
-      :dev -> "sandbox"
-      :test -> "sandbox"
     end
   end
 end

--- a/lib/plaidex/api/base.ex
+++ b/lib/plaidex/api/base.ex
@@ -26,6 +26,15 @@ defmodule Plaidex.API.Base do
     post(endpoint, parameters)
   end
 
+  def authenticated_post(params, endpoint) do
+    parameters = case params do
+      nil -> Plaidex.Config.credentials
+      params -> Plaidex.Config.credentials |> Enum.into(params)
+    end
+
+    post(endpoint, parameters)
+  end
+
   def delete(endpoint) do
     response = endpoint
                |> url

--- a/lib/plaidex/config.ex
+++ b/lib/plaidex/config.ex
@@ -12,6 +12,11 @@ defmodule Plaidex.Config do
     %{client_id: config[:plaid_client_id], secret: config[:plaid_secret], access_token: access_token}
   end
 
+  def credentials do
+    config = get()
+    %{client_id: config[:plaid_client_id], secret: config[:plaid_secret]}
+  end
+
   defp get(:global) do
     case Application.get_env(:plaidex, :plaidex_auth, nil) do
       nil -> set_application_env()

--- a/lib/plaidex/config.ex
+++ b/lib/plaidex/config.ex
@@ -17,6 +17,15 @@ defmodule Plaidex.Config do
     %{client_id: config[:plaid_client_id], secret: config[:plaid_secret]}
   end
 
+  def environment_url do
+    config = get()
+
+    case config[:plaid_env] do
+      nil -> default_env()
+      env -> env
+    end
+  end
+
   defp get(:global) do
     case Application.get_env(:plaidex, :plaidex_auth, nil) do
       nil -> set_application_env()
@@ -48,4 +57,11 @@ defmodule Plaidex.Config do
     :ok
   end
 
+  defp default_env do
+    case Mix.env do
+      :prod -> "production"
+      :dev -> "sandbox"
+      :test -> "sandbox"
+    end
+  end
 end

--- a/lib/plaidex/config.ex
+++ b/lib/plaidex/config.ex
@@ -20,9 +20,8 @@ defmodule Plaidex.Config do
   defp get(:global) do
     case Application.get_env(:plaidex, :plaidex_auth, nil) do
       nil -> set_application_env()
-      config -> config
+      config -> config |> Enum.into(%{})
     end
-    Application.get_env(:plaidex, :plaidex_auth, nil)
   end
 
   defp get(:process), do: Process.get(:plaidex_auth, nil)

--- a/test/fixture/vcr_cassettes/create_stripe_bank_token.json
+++ b/test/fixture/vcr_cassettes/create_stripe_bank_token.json
@@ -1,0 +1,31 @@
+[
+  {
+    "request": {
+      "body":
+        "{\"secret\":dec6ba05546855aa62717a9ded9834,\"client_id\":598ef95cbdc6a4059887f880,\"account_id\":\"sandbox-account-id\",\"access_token\":\"access-sandbox-token\"}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": {
+        "pool": "default"
+      },
+      "request_body": "",
+      "url":
+        "https://sandbox.plaid.com/processor/stripe/bank_account_token/create"
+    },
+    "response": {
+      "body":
+        "{\"stripe_bank_account_token\":\"btok_1BiwoUIk28pJ0gtl4aO2zErM\",\"request_id\":\"K4qE9\"}",
+      "headers": {
+        "Server": "nginx",
+        "Date": "Thu, 11 Jan 2018 03:35:39 GMT",
+        "Content-Type": "application/json",
+        "Content-Length": "201",
+        "Connection": "keep-alive"
+      },
+      "status_code": 400,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/public_token_exchange.json
+++ b/test/fixture/vcr_cassettes/public_token_exchange.json
@@ -1,0 +1,30 @@
+[
+  {
+    "request": {
+      "body":
+        "{\"secret\":\"dec6ba05546855aa62717a9ded9834\",\"public_token\":\"public-sandbox-access-token\",\"client_id\":\"598ef95cbdc6a4059887f880\"}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": {
+        "pool": "default"
+      },
+      "request_body": "",
+      "url": "https://sandbox.plaid.com/item/public_token/exchange"
+    },
+    "response": {
+      "body":
+        "{\"access_token\":\"access-sandbox-de3ce8ef-33f8-452c-a685-8671031fc0f6\",\"item_id\":\"M5eVJqLnv3tbzdngLDp9FL5OlDNxlNhlE55op\",\"request_id\": \"Aim3b\"}",
+      "headers": {
+        "Server": "nginx",
+        "Date": "Wed, 10 Jan 2018 21:22:00 GMT",
+        "Content-Type": "application/json",
+        "Content-Length": "201",
+        "Connection": "keep-alive"
+      },
+      "status_code": 400,
+      "type": "ok"
+    }
+  }
+]

--- a/test/plaidex.config_test.exs
+++ b/test/plaidex.config_test.exs
@@ -37,6 +37,15 @@ defmodule Plaidex.Config.Test do
     assert result[:plaid_secret] == "SHHHHhHhHHH"
   end
 
+  test "environment url default" do
+    assert Plaidex.Config.environment_url == "sandbox"
+  end
+
+  test "environment url" do
+    Application.put_env(:plaidex, :plaidex_auth, plaid_env: "development")
+    assert Plaidex.Config.environment_url == "development"
+  end
+
   test "setting a non env global config" do
     Plaidex.Config.set(
       :global,

--- a/test/plaidex.config_test.exs
+++ b/test/plaidex.config_test.exs
@@ -27,6 +27,16 @@ defmodule Plaidex.Config.Test do
     assert result[:plaid_secret] == nil
   end
 
+  test "application config" do
+    Application.put_env(:plaidex, :plaidex_auth,
+      plaid_client_id: "5551212",
+      plaid_secret: "SHHHHhHhHHH"
+    )
+    result = Plaidex.Config.get
+    assert result[:plaid_client_id] == "5551212"
+    assert result[:plaid_secret] == "SHHHHhHhHHH"
+  end
+
   test "setting a non env global config" do
     Plaidex.Config.set(
       :global,

--- a/test/plaidex_test.exs
+++ b/test/plaidex_test.exs
@@ -45,4 +45,15 @@ defmodule PlaidexTest do
              |> Map.get("amount") == -4.22
     end
   end
+
+  test "public_token_exchange" do
+    use_cassette "public_token_exchange" do
+      {:ok, result} = Plaidex.public_token_exchange(
+        public_token: "public-sandbox-cce1f57f-ceca-418f-bdfa-e0cbfee7c3e6"
+      )
+
+      assert result["access_token"]
+      assert result["item_id"]
+    end
+  end
 end

--- a/test/plaidex_test.exs
+++ b/test/plaidex_test.exs
@@ -56,4 +56,14 @@ defmodule PlaidexTest do
       assert result["item_id"]
     end
   end
+
+  test "create_stripe_bank_account_token" do
+    use_cassette "create_stripe_bank_token" do
+      {:ok, result} = Plaidex.create_stripe_bank_token("access-sandbox-token",
+        account_id: "sandbox-account-id"
+      )
+
+      assert result["stripe_bank_account_token"]
+    end
+  end
 end


### PR DESCRIPTION
I’m using this package to connect to Plaid, but needed two additional APIs unavailable in the base package. I added them and am using a fork in my project, but thought I’d contribute them back to this repo!

I tried to follow the format/convention of the existing code as much as possible.

1. Adds the `public_exchange_token` API [docs](https://plaid.com/docs/api/#exchange-token-flow)
2. Adds the Stripe bank account token API [docs](https://plaid.com/docs/link/stripe/3)